### PR TITLE
bootstrap code fixes

### DIFF
--- a/counterpartycli/util.py
+++ b/counterpartycli/util.py
@@ -118,11 +118,11 @@ def bootstrap(testnet=False, overwrite=True, ask_confirmation=False):
 
     # Set Constants.
     if testnet:
-        BOOTSTRAP_URL = 'https://s3.amazonaws.com/counterparty-bootstrap/counterpartyd-testnet-db.latest.tar.gz'
+        BOOTSTRAP_URL = 'https://s3.amazonaws.com/counterparty-bootstrap/counterparty-db-testnet.latest.tar.gz'
         TARBALL_PATH = os.path.join(tempfile.gettempdir(), 'counterpartyd-testnet-db.latest.tar.gz')
         DATABASE_PATH = os.path.join(data_dir, '{}.testnet.db'.format(config.APP_NAME))
     else:
-        BOOTSTRAP_URL = 'https://s3.amazonaws.com/counterparty-bootstrap/counterpartyd-db.latest.tar.gz'
+        BOOTSTRAP_URL = 'https://s3.amazonaws.com/counterparty-bootstrap/counterparty-db.latest.tar.gz'
         TARBALL_PATH = os.path.join(tempfile.gettempdir(), 'counterpartyd-db.latest.tar.gz')
         DATABASE_PATH = os.path.join(data_dir, '{}.db'.format(config.APP_NAME))
 


### PR DESCRIPTION
bootstrap code fixes:
* update the bootstrap routine to work again (I updated the bootstrap archive system to the newest code, and the new tarballs don't have .9.db anymore in the filenames.
* improved bootstrap code to download the files to the system tempdir instead of pwd. this means you can call bootstrap from anywhere, not just from a dir you can write to

Note that the existing bootstrap code still works (or should work) since the old archives are still there for now

tested and appears to work well
