### PR TITLE
add `--disable-utxo-locks`

### DIFF
--- a/counterpartycli/client.py
+++ b/counterpartycli/client.py
@@ -48,6 +48,7 @@ CONFIG_ARGS = [
     [('--multisig-dust-size',), {'type': D, 'default': D(config.DEFAULT_MULTISIG_DUST_SIZE / config.UNIT), 'help': 'for dust OP_CHECKMULTISIG outputs, in {}'.format(config.BTC)}],
     [('--op-return-value',), {'type': D, 'default': D(config.DEFAULT_OP_RETURN_VALUE / config.UNIT), 'help': 'value for OP_RETURN outputs, in {}'.format(config.BTC)}],
     [('--unsigned',), {'action': 'store_true', 'default': False, 'help': 'print out unsigned hex of transaction; do not sign or broadcast'}],
+    [('--disable-utxo-locks',), {'action': 'store_true', 'default': False, 'help': 'disable locking of UTXOs being spend'}],
     [('--requests-timeout',), {'type': int, 'default': clientapi.DEFAULT_REQUESTS_TIMEOUT, 'help': 'timeout value (in seconds) used for all HTTP requests (default: 5)'}]
 ]
 

--- a/counterpartycli/client.py
+++ b/counterpartycli/client.py
@@ -49,6 +49,7 @@ CONFIG_ARGS = [
     [('--op-return-value',), {'type': D, 'default': D(config.DEFAULT_OP_RETURN_VALUE / config.UNIT), 'help': 'value for OP_RETURN outputs, in {}'.format(config.BTC)}],
     [('--unsigned',), {'action': 'store_true', 'default': False, 'help': 'print out unsigned hex of transaction; do not sign or broadcast'}],
     [('--disable-utxo-locks',), {'action': 'store_true', 'default': False, 'help': 'disable locking of UTXOs being spend'}],
+    [('--dust-return-pubkey',), {'help': 'pubkey for dust outputs (required for P2SH)'}],
     [('--requests-timeout',), {'type': int, 'default': clientapi.DEFAULT_REQUESTS_TIMEOUT, 'help': 'timeout value (in seconds) used for all HTTP requests (default: 5)'}]
 ]
 

--- a/counterpartycli/messages.py
+++ b/counterpartycli/messages.py
@@ -115,7 +115,8 @@ def common_args(args):
         'fee_per_kb': args.fee_per_kb,
         'regular_dust_size': args.regular_dust_size,
         'multisig_dust_size': args.multisig_dust_size,
-        'op_return_value': args.op_return_value
+        'op_return_value': args.op_return_value,
+        'disable_utxo_locks': args.disable_utxo_locks
     }
 
 def prepare_args(args, action):

--- a/counterpartycli/messages.py
+++ b/counterpartycli/messages.py
@@ -116,6 +116,7 @@ def common_args(args):
         'regular_dust_size': args.regular_dust_size,
         'multisig_dust_size': args.multisig_dust_size,
         'op_return_value': args.op_return_value,
+        'dust_return_pubkey': args.dust_return_pubkey,
         'disable_utxo_locks': args.disable_utxo_locks
     }
 
@@ -260,7 +261,7 @@ def compose_transaction(args, message_name, param_names):
     for address_name in ['source', 'destination']:
         if address_name in params:
             address = params[address_name]
-            if script.is_multisig(address) or address_name != 'destination':    # We don’t need the pubkey for a mono‐sig destination.
+            if not script.is_p2sh(address) and (script.is_multisig(address) or address_name != 'destination'):    # We don’t need the pubkey for a mono‐sig destination.
                 pubkeys += get_pubkeys(address)
     params['pubkey'] = pubkeys
 


### PR DESCRIPTION
Add CLI arg for: https://github.com/CounterpartyXCP/counterparty-lib/pull/903

add `disable_utxo_locks` to `transaction.construct` and `compose_transaction` to disable the locking of selected UTXOs for when the 'user' doesn't intend to broadcast the TX (straight away).

for payment channels you want to compose a TX but don't broadcast it (straight away) and if the UTXOs are locked you'll run into insufficient balance errors if you compose multiple times in quick succession. 

```
$ counterparty-client --unconfirmed --dust-return-pubkey=00 --testnet send --source 2NDeRsbNMWdZtvW5LWYoMcR4xqDkpEQgipb --destination 2N9dnUBopgzqybN25Zc2Gf9udAkaCFRvWz4 --quantity 1 --asset XCP --fee 0.0001 
[2016-06-15 16:52:42][INFO] Transaction (unsigned): 010000000256fcef7e4542b383423bef8ee5f5d98257175aee773e36e07e7f88a53fa30c260000000017a914dfc600ebdb0e9d460cf161dd8217b9e19f03eb0787ffffffff1ae39de1043bed48aed352c6d5b1f0f54b4f28d5464ecbb5418e7e9f06a6f0a50200000017a914dfc600ebdb0e9d460cf161dd8217b9e19f03eb0787ffffffff03351500000000000017a914b3c6470d6211d650baad37581a1f8a1f1f387b0f8700000000000000001e6a1c2649a3048bae88b3464679eadffaf6170930d4fc076214571ba55c34417a0e050000000017a914dfc600ebdb0e9d460cf161dd8217b9e19f03eb078700000000
Sign and broadcast? (y/N) N

$ counterparty-client --unconfirmed --dust-return-pubkey=00 --testnet send --source 2NDeRsbNMWdZtvW5LWYoMcR4xqDkpEQgipb --destination 2N9dnUBopgzqybN25Zc2Gf9udAkaCFRvWz4 --quantity 1 --asset XCP --fee 0.0001 
[2016-06-15 16:52:44][INFO] Transaction (unsigned): 0100000001ed4419a09477a14b18e1fbbd4c7ede78f7786cb9a65383922c1c365acbb127910200000017a914dfc600ebdb0e9d460cf161dd8217b9e19f03eb0787ffffffff03351500000000000017a914b3c6470d6211d650baad37581a1f8a1f1f387b0f8700000000000000001e6a1c13e5dd7fcb4d054e2ac207e69234558d8a9a1677cdd059778e4041e66f964b000000000017a914dfc600ebdb0e9d460cf161dd8217b9e19f03eb078700000000
Sign and broadcast? (y/N) N

$ counterparty-client --unconfirmed --dust-return-pubkey=00 --testnet send --source 2NDeRsbNMWdZtvW5LWYoMcR4xqDkpEQgipb --destination 2N9dnUBopgzqybN25Zc2Gf9udAkaCFRvWz4 --quantity 1 --asset XCP --fee 0.0001 
counterpartycli.util.RPCError: {'code': -32001, 'message': 'Error composing send transaction via API: Insufficient BTC at address 2NDeRsbNMWdZtvW5LWYoMcR4xqDkpEQgipb. (Need approximately 0.00015429 BTC.) To spend unconfirmed coins, use the flag `--unconfirmed`. (Unconfirmed coins cannot be spent from multi‐sig addresses.)'}
```

```
$ counterparty-client --disable-utxo-locks --unconfirmed --dust-return-pubkey=00 --testnet send --source 2NDeRsbNMWdZtvW5LWYoMcR4xqDkpEQgipb --destination 2N9dnUBopgzqybN25Zc2Gf9udAkaCFRvWz4 --quantity 1 --asset XCP --fee 0.0001 
[2016-06-15 16:54:09][INFO] Transaction (unsigned): 010000000256fcef7e4542b383423bef8ee5f5d98257175aee773e36e07e7f88a53fa30c260000000017a914dfc600ebdb0e9d460cf161dd8217b9e19f03eb0787ffffffff1ae39de1043bed48aed352c6d5b1f0f54b4f28d5464ecbb5418e7e9f06a6f0a50200000017a914dfc600ebdb0e9d460cf161dd8217b9e19f03eb0787ffffffff03351500000000000017a914b3c6470d6211d650baad37581a1f8a1f1f387b0f8700000000000000001e6a1c2649a3048bae88b3464679eadffaf6170930d4fc076214571ba55c34417a0e050000000017a914dfc600ebdb0e9d460cf161dd8217b9e19f03eb078700000000
Sign and broadcast? (y/N) N

$ counterparty-client --disable-utxo-locks --unconfirmed --dust-return-pubkey=00 --testnet send --source 2NDeRsbNMWdZtvW5LWYoMcR4xqDkpEQgipb --destination 2N9dnUBopgzqybN25Zc2Gf9udAkaCFRvWz4 --quantity 1 --asset XCP --fee 0.0001 
[2016-06-15 16:54:09][INFO] Transaction (unsigned): 010000000256fcef7e4542b383423bef8ee5f5d98257175aee773e36e07e7f88a53fa30c260000000017a914dfc600ebdb0e9d460cf161dd8217b9e19f03eb0787ffffffff1ae39de1043bed48aed352c6d5b1f0f54b4f28d5464ecbb5418e7e9f06a6f0a50200000017a914dfc600ebdb0e9d460cf161dd8217b9e19f03eb0787ffffffff03351500000000000017a914b3c6470d6211d650baad37581a1f8a1f1f387b0f8700000000000000001e6a1c2649a3048bae88b3464679eadffaf6170930d4fc076214571ba55c34417a0e050000000017a914dfc600ebdb0e9d460cf161dd8217b9e19f03eb078700000000
Sign and broadcast? (y/N) N

$ counterparty-client --disable-utxo-locks --unconfirmed --dust-return-pubkey=00 --testnet send --source 2NDeRsbNMWdZtvW5LWYoMcR4xqDkpEQgipb --destination 2N9dnUBopgzqybN25Zc2Gf9udAkaCFRvWz4 --quantity 1 --asset XCP --fee 0.0001 
[2016-06-15 16:54:09][INFO] Transaction (unsigned): 010000000256fcef7e4542b383423bef8ee5f5d98257175aee773e36e07e7f88a53fa30c260000000017a914dfc600ebdb0e9d460cf161dd8217b9e19f03eb0787ffffffff1ae39de1043bed48aed352c6d5b1f0f54b4f28d5464ecbb5418e7e9f06a6f0a50200000017a914dfc600ebdb0e9d460cf161dd8217b9e19f03eb0787ffffffff03351500000000000017a914b3c6470d6211d650baad37581a1f8a1f1f387b0f8700000000000000001e6a1c2649a3048bae88b3464679eadffaf6170930d4fc076214571ba55c34417a0e050000000017a914dfc600ebdb0e9d460cf161dd8217b9e19f03eb078700000000
Sign and broadcast? (y/N) N
```