### PR TITLE
fix counterparty-client NoneType error

### DIFF
--- a/counterpartycli/client.py
+++ b/counterpartycli/client.py
@@ -68,7 +68,7 @@ def main():
     parser.add_argument('-V', '--version', action='version', version="{} v{}; {} v{}".format(APP_NAME, APP_VERSION, 'counterparty-lib', config.VERSION_STRING))
     parser.add_argument('--config-file', help='the location of the configuration file')
 
-    parser = add_config_arguments(parser, CONFIG_ARGS, 'client.conf')
+    add_config_arguments(parser, CONFIG_ARGS, 'client.conf')
 
     subparsers = parser.add_subparsers(dest='action', help='the action to be taken')
 


### PR DESCRIPTION
fixes:

```
$ counterparty-client --help
Traceback (most recent call last):
  File "/bin/counterparty-client", line 9, in <module>
    load_entry_point('counterparty-cli==1.1.2', 'console_scripts', 'counterparty-client')()
  File "/usr/lib/python3.5/site-packages/counterpartycli/__init__.py", line 12, in client_main
    client.main()
  File "/usr/lib/python3.5/site-packages/counterpartycli/client.py", line 73, in main
    subparsers = parser.add_subparsers(dest='action', help='the action to be taken')
AttributeError: 'NoneType' object has no attribute 'add_subparsers'
```