### PR TITLE
Update deprecated pycoin syntax

### DIFF
--- a/counterpartycli/wallet/__init__.py
+++ b/counterpartycli/wallet/__init__.py
@@ -48,7 +48,7 @@ def pycoin_sign_raw_transaction(tx_hex, private_key_wif):
     hash160 = public_pair_to_hash160_sec(public_pair, compressed)
     hash160_lookup = {hash160: (secret_exponent, public_pair, compressed)}
 
-    tx = Tx.tx_from_hex(tx_hex)
+    tx = Tx.from_hex(tx_hex)
     for idx, tx_in in enumerate(tx.txs_in):
         tx.sign_tx_in(hash160_lookup, idx, tx_in.script, hash_type=SIGHASH_ALL)
 


### PR DESCRIPTION
* `tx_from_hex` was deprecated in pycoin 0.60 (we're using 0.62); the new syntax is `from_hex`
* This is the only occurrence in this repo
* Relevant pycoin commit: https://github.com/richardkiss/pycoin/commit/6b80872e83b66bb030f5d357baeed5b5ad220ff7
* Fixes the warning observed in #99