### PR TITLE
Changes for working with Bitcoincore 0.18.0 (not backwards compatible)

### DIFF
--- a/counterpartycli/wallet/bitcoincore.py
+++ b/counterpartycli/wallet/bitcoincore.py
@@ -32,12 +32,13 @@ def is_valid(address):
     return rpc('validateaddress', [address])['isvalid']
 
 def is_mine(address):
-    return rpc('validateaddress', [address])['ismine']
+    return rpc('getaddressinfo', [address])['ismine']
 
 def get_pubkey(address):
     address_infos = rpc('validateaddress', [address])
-    if address_infos['isvalid'] and address_infos['ismine']:
-        return address_infos['pubkey']
+    get_address_infos = rpc('getaddressinfo', [address])
+    if address_infos['isvalid'] and get_address_infos['ismine']:
+        return get_address_infos['pubkey']
     return None
 
 def get_btc_balance(address):

--- a/counterpartycli/wallet/btcwallet.py
+++ b/counterpartycli/wallet/btcwallet.py
@@ -40,15 +40,16 @@ def is_valid(address):
     return False
 
 def is_mine(address):
-    address_info = rpc('validateaddress', [address])
+    address_info = rpc('getaddressinfo', [address])
     if 'ismine' not in address_info:
         return False
     return address_info['ismine']
 
 def get_pubkey(address):
     address_infos = rpc('validateaddress', [address])
-    if address_infos['isvalid'] and address_infos['ismine']:
-        return address_infos['pubkey']
+    get_address_infos = rpc('validateaddress', [address])
+    if address_infos['isvalid'] and get_address_infos['ismine']:
+        return get_address_infos['pubkey']
     return None
 
 def get_btc_balance(address):


### PR DESCRIPTION
Client is still checking for ismine property using validateaddress Bitcoin API method, which has been deprecated and does not exist anymore in 0.18.0. Changed it to use getaddressinfo.